### PR TITLE
Add Comments.tmPreferences

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.hare</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This adds syntax highlighting for [Hare](https://harelang.org) to Sublime Text.
 
-It's literally just `hare.sublime-syntax`.
+It's literally just `hare.sublime-syntax` and `Comments.tmPreferences`.
 
 This was generated from the `hare.tmLanguage.json` file in: https://github.com/aDotInTheVoid/hare-highlighing-vscode
 

--- a/hare.sublime-syntax
+++ b/hare.sublime-syntax
@@ -15,41 +15,41 @@ contexts:
     - include: boolean
     - include: int_dec_lit
     - include: char_lit
-      #  Comparison operator:
+    # Comparison operator:
     - match: (&&|\|\||==|!=)
       scope: keyword.operator.comparison.hare
-      #  Assignment operator:
+    # Assignment operator:
     - match: (\+=|-=|/=|\*=|%=|\^=|&=|\|=|<<=|>>=|=)
       scope: keyword.operator.assignment.hare
-      #  Arithmetic operator:
+    # Arithmetic operator:
     - match: (!|\+|-|/|\*|%|\^|&|\||<<|>>)
       scope: keyword.operator.arithmetic.hare
-      #  Comparison operator (second group because of regex precedence):
+    # Comparison operator (second group because of regex precedence):
     - match: (<=|>=|<|>)
       scope: keyword.operator.comparison.hare
-      #  Preprocessor Directive:
+    # Preprocessor Directive:
     - match: '(@[a-z]+)'
       scope: comment.block.preprocessor.hare
-      #  Conversion Operators:
+    # Conversion Operators:
     - match: \b(is|as)\b
       scope: keyword.operator.conversion.hare
 
-  #  Boolean constant
+  # Boolean constant
   boolean:
     - match: \b(true|false)\b
       scope: constant.language.boolean.hare
 
-  #  Single-quote string literal (character)
+  # Single-quote string literal (character)
   char_lit:
     - match: 'b?''([^''\\]|\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))'''
       scope: string.quoted.single.hare
 
-  #  Built-in/core type
+  # Built-in/core type
   core_types:
     - match: \b(str|rune|char|bool|int|uint|uintptr|u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|null|void|nullable|valist)\b
       scope: support.type.primitive.hare
 
-  #  Integer literal (decimal)
+  # Integer literal (decimal)
   int_dec_lit:
     - match: '\b[0-9][0-9_]*\b'
       scope: constant.numeric.integer.decimal.hare
@@ -65,7 +65,7 @@ contexts:
         - match: $
           pop: true
 
-  #  Miscellaneous operator
+  # Miscellaneous operators
   misc_ops:
     - match: (=>|::|:|\?|!|\|)
       scope: keyword.operator.misc.hare

--- a/hare.sublime-syntax
+++ b/hare.sublime-syntax
@@ -15,53 +15,61 @@ contexts:
     - include: boolean
     - include: int_dec_lit
     - include: char_lit
+      #  Comparison operator:
     - match: (&&|\|\||==|!=)
-      comment: Comparison operator
       scope: keyword.operator.comparison.hare
+      #  Assignment operator:
     - match: (\+=|-=|/=|\*=|%=|\^=|&=|\|=|<<=|>>=|=)
-      comment: Assignment operator
       scope: keyword.operator.assignment.hare
+      #  Arithmetic operator:
     - match: (!|\+|-|/|\*|%|\^|&|\||<<|>>)
-      comment: Arithmetic operator
       scope: keyword.operator.arithmetic.hare
+      #  Comparison operator (second group because of regex precedence):
     - match: (<=|>=|<|>)
-      comment: Comparison operator (second group because of regex precedence)
       scope: keyword.operator.comparison.hare
+      #  Preprocessor Directive:
     - match: '(@[a-z]+)'
-      comment: Preprocessor Directive
       scope: comment.block.preprocessor.hare
+      #  Conversion Operators:
     - match: \b(is|as)\b
-      comment: Conversion Operators
       scope: keyword.operator.conversion.hare
+
+  #  Boolean constant
   boolean:
     - match: \b(true|false)\b
-      comment: Boolean constant
       scope: constant.language.boolean.hare
+
+  #  Single-quote string literal (character)
   char_lit:
     - match: 'b?''([^''\\]|\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))'''
-      comment: Single-quote string literal (character)
       scope: string.quoted.single.hare
+
+  #  Built-in/core type
   core_types:
     - match: \b(str|rune|char|bool|int|uint|uintptr|u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|null|void|nullable|valist)\b
-      comment: Built-in/core type
       scope: support.type.primitive.hare
+
+  #  Integer literal (decimal)
   int_dec_lit:
     - match: '\b[0-9][0-9_]*\b'
-      comment: Integer literal (decimal)
       scope: constant.numeric.integer.decimal.hare
+
   keywords:
     - match: \b(abort|alloc|append|assert|break|case|const|continue|def|defer|delete|else|enum|export|fn|for|free|if|insert|len|let|match|offset|return|size|static|struct|switch|type|union|vaarg|vaend|vastart|yield|use)\b
       scope: keyword.control.hare
+
   line_comment:
     - match: //
       push:
         - meta_scope: comment.line.double-slash.hare
         - match: $
           pop: true
+
+  #  Miscellaneous operator
   misc_ops:
     - match: (=>|::|:|\?|!|\|)
-      comment: Miscellaneous operator
       scope: keyword.operator.misc.hare
+
   strings:
     - match: '"'
       push:
@@ -70,6 +78,7 @@ contexts:
           pop: true
         - match: \\.
           scope: constant.character.escape.hare
+
   strings_2:
     - match: '`'
       push:


### PR DESCRIPTION
This PR adds Comments.tmPreferences, which enables toggling comments with the hotkey. See [this forum post](https://forum.sublimetext.com/t/toggle-comment-with-a-custom-sublime-syntax/18789
) for more details.

Thanks for making this plugin!

Can we add [The Unlicense](https://choosealicense.com/licenses/unlicense/)?

